### PR TITLE
Simplify mission setup

### DIFF
--- a/src/components/game/ActionStepRow.svelte
+++ b/src/components/game/ActionStepRow.svelte
@@ -59,8 +59,8 @@
     flex-shrink: 0;
   }
   .action-tag.mod {
-    background: rgba(0,180,216,0.12);
-    border: 1px solid rgba(0,180,216,0.3);
+    background: rgba(0,191,165,0.12);
+    border: 1px solid rgba(0,191,165,0.3);
     color: var(--color-cyan);
   }
   .action-tag.type {

--- a/src/components/game/SetupScreen.svelte
+++ b/src/components/game/SetupScreen.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import {
-    gameStore, adversaryGroups,
-    setSetupType, setSetupDifficulty, toggleSetupColor,
-    addAdversaryGroup, clearAdversaries, goToBattle,
+    gameStore,
+    setSetupDifficulty, toggleSetupType, startBattle,
   } from '../../stores/gameStore';
   import { ADVERSARY_TYPES } from '../../lib/adversaries';
   import { adversaryIconUrl, adversaryPortraitUrl } from '../../lib/assets';
-  import { DIFFICULTY_STARS, ADVERSARY_COLORS, COLOR_VAR } from '../../lib/constants';
-  import type { AdversaryStatBlock, AdversaryType, DifficultyLevel } from '../../types/game';
+  import { DIFFICULTY_STARS } from '../../lib/constants';
+  import type { AdversaryStatBlock, DifficultyLevel } from '../../types/game';
 
   const LEVELS: DifficultyLevel[] = [0, 1, 2, 3];
 
@@ -17,344 +16,197 @@
     fetch('/game-data/data/adversary-stats.json').then(r => r.json()).then(d => statsJson = d);
   });
 
-  $: setup       = $gameStore.setup;
-  $: selectedType = ADVERSARY_TYPES.find(t => t.name === setup.selectedTypeName) ?? null;
-  $: difficulty  = setup.difficulty;
-  $: colorToggles = setup.colorToggles;
-  $: groups      = $adversaryGroups;
-
-  $: selectedStats = (selectedType && statsJson)
-    ? (statsJson[selectedType.name]?.[difficulty] ?? null)
+  $: setup          = $gameStore.setup;
+  $: difficulty     = setup.difficulty;
+  $: selectedTypes  = new Set(setup.selectedTypes);
+  $: focusedName    = setup.selectedTypeName;
+  $: focusedStats   = (focusedName && statsJson)
+    ? (statsJson[focusedName]?.[difficulty] ?? null)
     : null;
+  $: canBattle = setup.selectedTypes.length > 0;
 
-  $: addedNames = new Set(groups.map(g => g.name));
-  $: canAdd    = !!selectedType && ADVERSARY_COLORS.some(c => colorToggles[c]);
-  $: canBattle = groups.length > 0;
-
-  let adding = false;
-  async function handleAdd() {
-    if (!selectedType || adding) return;
-    adding = true;
-    await addAdversaryGroup(selectedType, difficulty, colorToggles);
-    adding = false;
-  }
-
-  function handleBattle() {
-    if (!canBattle) return;
-    goToBattle();
+  let starting = false;
+  async function handleBattle() {
+    if (!canBattle || starting) return;
+    starting = true;
+    await startBattle();
+    starting = false;
   }
 </script>
 
-<div class="setup-layout">
-  <div class="panel-left">
-    <!-- Added adversary groups list -->
-    <div class="list-header">
-      <span class="header-title">
-        Mission Roster
-        {#if groups.length > 0}
-          <span class="count-badge">{groups.length}</span>
-        {/if}
-      </span>
-    </div>
-    <div class="list-body">
-      {#if groups.length === 0}
-        <div class="empty-state">
-          <p>No adversaries added yet.</p>
-          <p class="hint">Select a type from the right, then tap Add.</p>
-        </div>
-      {:else}
-        {#each groups as group}
-          <div class="group-row">
-            <img src={adversaryIconUrl(group.name)} alt="" class="group-icon" />
-            <div class="group-info">
-              <span class="group-name">{group.name}</span>
-              <span class="group-diff">{DIFFICULTY_STARS[group.difficulty]}</span>
-            </div>
-            <div class="group-colors">
-              {#each ADVERSARY_COLORS as color}
-                {@const unit = group.units.find(u => u.color === color)}
-                {#if unit}
-                  <span
-                    class="color-pip"
-                    style="background:{COLOR_VAR[color]}"
-                    title={color}
-                  ></span>
-                {/if}
-              {/each}
-            </div>
-          </div>
-        {/each}
-      {/if}
-    </div>
-  </div>
+<div class="setup-screen">
 
-  <div class="panel-right">
-    <!-- Top: selected type detail -->
-    <div class="right-top">
-      {#if selectedType}
-        <div class="adv-header">
-          <img src={adversaryPortraitUrl(selectedType.name)} alt={selectedType.name} class="portrait" />
-          <div class="adv-meta">
-            <div class="name-row">
-              <span class="adv-name">{selectedType.name}</span>
-              <span class="stars">{DIFFICULTY_STARS[difficulty]}</span>
-            </div>
-            {#if selectedStats}
-              <div class="stats-inline">
-                <span class="si"><span class="sl">HP</span><span class="sv">{selectedStats.HP}</span></span>
-                <span class="si-sep"></span>
-                <span class="si"><span class="sl">Guard</span><span class="sv">{selectedStats.GUARD}</span></span>
-                <span class="si-sep"></span>
-                <span class="si"><span class="sl">Atk</span><span class="sv">{selectedStats.ATTACK}</span></span>
-                <span class="si-sep"></span>
-                <span class="si"><span class="sl">Rng</span><span class="sv">{selectedStats.RANGE}</span></span>
-              </div>
-              <div class="crit-line">
-                <span class="crit-lbl">Crit</span>
-                <span class="crit-val">{selectedStats.CRIT}</span>
-              </div>
-            {/if}
-          </div>
-        </div>
-      {:else}
-        <div class="no-sel">Select an adversary type below.</div>
-      {/if}
-    </div>
-
-    <!-- Bottom: 22-type picker grid -->
-    <div class="right-bottom">
-      <div class="type-grid">
-        {#each ADVERSARY_TYPES as type}
+  <!-- Top strip: difficulty selector + focused type stats preview -->
+  <div class="top-strip">
+    <div class="diff-group">
+      <span class="strip-label">Difficulty</span>
+      <div class="diff-btns">
+        {#each LEVELS as level}
           <button
-            class="type-cell"
-            class:sel={setup.selectedTypeName === type.name}
-            class:added={addedNames.has(type.name)}
-            disabled={addedNames.has(type.name)}
-            on:click={() => setSetupType(type.name)}
-          >
-            <img src={adversaryIconUrl(type.name)} alt={type.name} class="type-icon" />
-            <span class="type-name">{type.name}</span>
-          </button>
+            class="diff-btn"
+            class:active={difficulty === level}
+            on:click={() => setSetupDifficulty(level)}
+          >{DIFFICULTY_STARS[level]}</button>
         {/each}
       </div>
     </div>
+
+    <div class="strip-sep"></div>
+
+    {#if focusedName && focusedStats}
+      <div class="stats-preview">
+        <img src={adversaryPortraitUrl(focusedName)} alt={focusedName} class="preview-portrait" />
+        <span class="preview-name">{focusedName}</span>
+        <div class="preview-stats">
+          <span class="ps"><span class="pl">HP</span><span class="pv">{focusedStats.HP}</span></span>
+          <span class="ps-sep"></span>
+          <span class="ps"><span class="pl">Guard</span><span class="pv">{focusedStats.GUARD}</span></span>
+          <span class="ps-sep"></span>
+          <span class="ps"><span class="pl">Atk</span><span class="pv">{focusedStats.ATTACK}</span></span>
+          <span class="ps-sep"></span>
+          <span class="ps"><span class="pl">Rng</span><span class="pv">{focusedStats.RANGE}</span></span>
+          <span class="ps-sep"></span>
+          <span class="ps"><span class="pl">Crit</span><span class="pv pv-crit">{focusedStats.CRIT}</span></span>
+        </div>
+      </div>
+    {:else}
+      <div class="strip-hint">Click a type to preview stats</div>
+    {/if}
   </div>
+
+  <!-- Type picker grid — full width, click to toggle in/out of mission -->
+  <div class="grid-area">
+    <div class="type-grid">
+      {#each ADVERSARY_TYPES as type}
+        <button
+          class="type-cell"
+          class:active={selectedTypes.has(type.name)}
+          class:focused={focusedName === type.name}
+          on:click={() => toggleSetupType(type.name)}
+        >
+          <img src={adversaryIconUrl(type.name)} alt={type.name} class="type-icon" />
+          <span class="type-name">{type.name}</span>
+          {#if selectedTypes.has(type.name)}
+            <span class="in-play-dot"></span>
+          {/if}
+        </button>
+      {/each}
+    </div>
+  </div>
+
 </div>
 
 <!-- Setup bottom bar -->
 <div class="setup-bar">
-  <!-- Difficulty -->
-  <div class="bar-group diff-group">
-    <span class="bar-label">Diff</span>
-    <div class="diff-btns">
-      {#each LEVELS as level}
-        <button
-          class="diff-btn"
-          class:active={difficulty === level}
-          on:click={() => setSetupDifficulty(level)}
-        >
-          {DIFFICULTY_STARS[level]}
-        </button>
-      {/each}
-    </div>
-  </div>
-
-  <div class="bar-sep"></div>
-
-  <!-- Color toggles -->
-  <div class="bar-group color-group">
-    <span class="bar-label">Colors</span>
-    <div class="color-btns">
-      {#each ADVERSARY_COLORS as color}
-        <button
-          class="color-btn"
-          class:active={colorToggles[color]}
-          style="--c:{COLOR_VAR[color]}"
-          on:click={() => toggleSetupColor(color)}
-          title={color}
-        >
-          {color[0]}
-        </button>
-      {/each}
-    </div>
-  </div>
-
-  <div class="bar-sep"></div>
-
-  <!-- Actions -->
+  <span class="sel-count">
+    {#if setup.selectedTypes.length > 0}
+      {setup.selectedTypes.length} {setup.selectedTypes.length === 1 ? 'type' : 'types'} in mission
+    {:else}
+      Select adversary types to begin
+    {/if}
+  </span>
   <button
-    class="bar-btn add-btn"
-    on:click={handleAdd}
-    disabled={!canAdd || adding}
-  >
-    {adding ? 'Adding...' : 'Add'}
-  </button>
-
-  <button
-    class="bar-btn clear-btn"
-    on:click={clearAdversaries}
-    disabled={groups.length === 0}
-  >
-    Clear
-  </button>
-
-  <button
-    class="bar-btn battle-btn"
+    class="battle-btn"
     on:click={handleBattle}
-    disabled={!canBattle}
+    disabled={!canBattle || starting}
   >
-    In battle!
+    {starting ? 'Starting...' : 'In Battle!'}
   </button>
 </div>
 
 <style>
-  .setup-layout {
-    display: flex;
+  .setup-screen {
     flex: 1;
-    overflow: hidden;
-  }
-
-  /* Left panel - same width as game screen */
-  .panel-left {
-    width: var(--panel-left-width);
-    border-right: 1px solid var(--color-border);
     display: flex;
     flex-direction: column;
     overflow: hidden;
   }
 
-  .list-header {
+  /* Top strip */
+  .top-strip {
+    flex-shrink: 0;
     display: flex;
     align-items: center;
-    padding: var(--space-2) var(--space-3);
-    border-bottom: 1px solid var(--color-border);
+    gap: var(--space-4);
+    padding: var(--space-3) var(--space-4);
     background: var(--color-surface);
-    border-top: 1px solid var(--color-accent);
-    flex-shrink: 0;
+    border-bottom: 1px solid var(--color-border);
+    border-top: 2px solid;
+    border-image-source: var(--brass-border-h);
+    border-image-slice: 1;
+    min-height: 64px;
   }
-  .header-title {
+
+  .diff-group { display: flex; align-items: center; gap: var(--space-2); flex-shrink: 0; }
+  .strip-label {
     font-size: 11px;
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: var(--color-text-dim);
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
   }
-  .count-badge {
+  .diff-btns { display: flex; gap: 3px; }
+  .diff-btn {
+    padding: 2px var(--space-2);
     background: var(--color-surface-alt);
     border: 1px solid var(--color-border);
-    border-radius: 10px;
-    padding: 0 var(--space-2);
-    font-size: 11px;
-  }
-
-  .list-body { flex: 1; overflow-y: auto; }
-
-  .empty-state {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: var(--space-2);
-    padding: var(--space-8) var(--space-4);
+    border-radius: var(--radius-sm);
     color: var(--color-text-dim);
-    font-style: italic;
-    font-size: 13px;
-    text-align: center;
+    font-size: 14px;
+    cursor: pointer;
+    min-height: 40px;
+    transition: all 0.1s;
   }
-  .hint { font-size: 11px; }
+  .diff-btn:hover  { border-color: var(--color-accent-dim); color: var(--color-text); }
+  .diff-btn.active { border-color: var(--color-accent); color: var(--color-accent); background: rgba(184,115,51,0.1); }
 
-  .group-row {
+  .strip-sep { width: 1px; height: 40px; background: var(--color-border); flex-shrink: 0; }
+
+  /* Stats preview */
+  .stats-preview {
+    flex: 1;
     display: flex;
     align-items: center;
     gap: var(--space-3);
-    padding: var(--space-3) var(--space-4);
-    border-bottom: 1px solid var(--color-border);
-  }
-  .group-icon { width: 48px; height: 48px; object-fit: contain; flex-shrink: 0; }
-  .group-info { flex: 1; display: flex; flex-direction: column; gap: 2px; }
-  .group-name { font-size: 17px; font-weight: 500; }
-  .group-diff { font-size: 13px; color: var(--color-accent); letter-spacing: 1px; }
-  .group-colors { display: flex; gap: var(--space-1); flex-shrink: 0; }
-  .color-pip {
-    width: 12px; height: 12px;
-    border-radius: 50%;
-    border: 1px solid rgba(255,255,255,0.2);
-  }
-
-  /* Right panel */
-  .panel-right {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-  }
-
-  /* Top: selected type detail (auto-height by content) */
-  .right-top {
-    flex-shrink: 0;
-    border-bottom: 2px solid var(--color-border);
-    display: flex;
-    flex-direction: column;
-  }
-
-  .adv-header {
-    display: flex;
-    align-items: flex-start;
-    gap: var(--space-3);
-    padding: var(--space-3);
-    background: var(--color-surface);
-    border-top: 1px solid var(--color-accent);
-  }
-  .portrait {
-    width: 56px;
-    height: 56px;
-    object-fit: contain;
-    filter: drop-shadow(0 2px 6px rgba(0,0,0,0.6));
-    flex-shrink: 0;
-  }
-  .adv-meta {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2);
     min-width: 0;
   }
-  .name-row { display: flex; align-items: baseline; gap: var(--space-2); }
-  .adv-name {
+  .preview-portrait {
+    width: 40px;
+    height: 40px;
+    object-fit: contain;
+    filter: drop-shadow(0 2px 4px rgba(0,0,0,0.7));
+    flex-shrink: 0;
+  }
+  .preview-name {
     font-family: var(--font-heading);
-    font-size: 18px;
+    font-size: 16px;
     color: var(--color-accent);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    flex-shrink: 0;
   }
-  .stars { font-size: 13px; color: var(--color-accent); letter-spacing: 1px; flex-shrink: 0; }
-
-  .stats-inline { display: flex; align-items: center; }
-  .si { display: flex; flex-direction: column; align-items: center; padding: 0 var(--space-3); }
-  .si:first-child { padding-left: 0; }
-  .si-sep { width: 1px; height: 28px; background: var(--color-border); flex-shrink: 0; }
-  .sl { font-size: 9px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--color-text-dim); margin-bottom: 1px; }
-  .sv { font-size: 20px; font-weight: bold; line-height: 1; }
-  .crit-line { display: flex; align-items: baseline; gap: var(--space-2); font-size: 13px; }
-  .crit-lbl { font-size: 9px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--color-text-dim); }
-  .crit-val { font-size: 13px; color: var(--color-text); font-style: italic; }
-
-  .no-sel {
-    flex: 1;
+  .preview-stats {
     display: flex;
     align-items: center;
-    justify-content: center;
+    gap: 0;
+    flex-wrap: nowrap;
+  }
+  .ps { display: flex; flex-direction: column; align-items: center; padding: 0 var(--space-2); }
+  .ps-sep { width: 1px; height: 24px; background: var(--color-border); flex-shrink: 0; }
+  .pl { font-size: 9px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--color-text-dim); margin-bottom: 1px; }
+  .pv { font-size: 18px; font-weight: bold; line-height: 1; }
+  .pv-crit { font-size: 13px; font-style: italic; font-weight: normal; }
+
+  .strip-hint {
+    flex: 1;
     color: var(--color-text-dim);
     font-style: italic;
-    padding: var(--space-8);
-    border-top: 1px solid var(--color-accent);
-    background: var(--color-surface);
+    font-size: 13px;
+    padding-left: var(--space-2);
   }
 
-  /* Bottom: type picker grid (fills remaining space) */
-  .right-bottom {
+  /* Type grid */
+  .grid-area {
     flex: 1;
     min-height: 0;
     overflow-y: auto;
@@ -363,7 +215,7 @@
 
   .type-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
     gap: var(--space-2);
     padding: var(--space-3);
   }
@@ -374,39 +226,30 @@
     flex-direction: column;
     align-items: center;
     gap: var(--space-1);
-    padding: var(--space-2);
+    padding: var(--space-2) var(--space-2) var(--space-3);
     background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     cursor: pointer;
-    transition: border-color 0.12s;
+    transition: border-color 0.12s, opacity 0.12s;
+    opacity: 0.45;
     min-height: 44px;
   }
-  .type-cell:hover { border-color: var(--color-accent-dim); }
-  .type-cell.sel   { border-color: var(--color-accent); background: rgba(184,115,51,0.12); }
-  .type-cell:disabled,
-  .type-cell.added {
-    opacity: 0.45;
-    cursor: not-allowed;
-    pointer-events: none;
+  .type-cell:hover { border-color: var(--color-accent-dim); opacity: 0.75; }
+
+  /* In play — full presence */
+  .type-cell.active {
+    border-color: var(--color-accent);
+    background: rgba(184, 115, 51, 0.1);
+    opacity: 1;
   }
-  .type-cell.added::after {
-    content: 'Added';
-    position: absolute;
-    top: 4px;
-    right: 4px;
-    font-size: 8px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--color-positive);
-    background: rgba(58, 122, 74, 0.18);
-    border: 1px solid rgba(58, 122, 74, 0.4);
-    border-radius: var(--radius-sm);
-    padding: 1px 3px;
-    line-height: 1.4;
+  /* Last-clicked — preview focus ring (works on both active and inactive) */
+  .type-cell.focused {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
   }
-  .type-icon { width: 68px; height: 68px; object-fit: contain; }
+
+  .type-icon { width: 72px; height: 72px; object-fit: contain; }
   .type-name {
     font-size: 12px;
     font-weight: 500;
@@ -415,95 +258,52 @@
     line-height: 1.3;
   }
 
+  /* Small dot indicator at bottom of cell when in play */
+  .in-play-dot {
+    position: absolute;
+    bottom: 6px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    box-shadow: 0 0 4px var(--color-accent);
+  }
+
   /* Setup bottom bar */
   .setup-bar {
     height: var(--bottom-bar-height);
     flex-shrink: 0;
     display: flex;
     align-items: center;
-    gap: var(--space-2);
-    padding: 0 var(--space-3);
+    justify-content: space-between;
+    padding: 0 var(--space-4);
     background: var(--color-surface-alt);
     border-top: 3px solid;
     border-image-source: var(--brass-border-h);
     border-image-slice: 1;
   }
 
-  .bar-group { display: flex; align-items: center; gap: var(--space-2); }
-  .bar-label {
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--color-text-dim);
-  }
-  .bar-sep { width: 1px; height: 36px; background: var(--color-border); flex-shrink: 0; }
-
-  .diff-btns, .color-btns { display: flex; gap: 3px; }
-
-  .diff-btn {
-    padding: 2px var(--space-2);
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-sm);
-    color: var(--color-text-dim);
+  .sel-count {
     font-size: 13px;
-    cursor: pointer;
-    min-height: 40px;
-    transition: all 0.1s;
-  }
-  .diff-btn:hover  { border-color: var(--color-accent-dim); color: var(--color-text); }
-  .diff-btn.active { border-color: var(--color-accent); color: var(--color-accent); background: rgba(184,115,51,0.1); }
-
-  .color-btn {
-    width: 36px;
-    height: 36px;
-    border: 2px solid var(--color-border);
-    border-radius: var(--radius-sm);
-    background: transparent;
     color: var(--color-text-dim);
-    font-size: 13px;
-    font-weight: 700;
-    cursor: pointer;
-    transition: all 0.1s;
+    font-style: italic;
   }
-  .color-btn:hover  { border-color: var(--c); }
-  .color-btn.active { border-color: var(--c); color: var(--c); background: color-mix(in srgb, var(--c) 15%, transparent); }
-
-  /* Action buttons */
-  .bar-btn {
-    padding: 0 var(--space-3);
-    border-radius: var(--radius-md);
-    font-size: 15px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 0.12s;
-    white-space: nowrap;
-    min-height: 44px;
-  }
-  .bar-btn:disabled { opacity: 0.35; cursor: not-allowed; }
-
-  .add-btn {
-    background: var(--color-accent-dim);
-    color: var(--color-text);
-    border: 1px solid var(--color-accent);
-  }
-  .add-btn:hover:not(:disabled) { background: var(--color-accent); }
-
-  .clear-btn {
-    background: none;
-    color: var(--color-text-dim);
-    border: 1px solid var(--color-border);
-  }
-  .clear-btn:hover:not(:disabled) { border-color: var(--color-red); color: var(--color-red); }
 
   .battle-btn {
+    padding: 0 var(--space-6);
+    min-height: 44px;
     background: var(--color-accent);
     color: var(--color-bg);
     border: none;
+    border-radius: var(--radius-md);
+    font-size: 16px;
     font-weight: 700;
     letter-spacing: 0.04em;
-    margin-left: auto;
-    padding: 0 var(--space-4);
+    cursor: pointer;
+    transition: filter 0.12s;
   }
   .battle-btn:hover:not(:disabled) { filter: brightness(1.15); }
+  .battle-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 </style>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,7 +15,7 @@ export const COLOR_VAR: Record<AdversaryColor, string> = {
 
 export const COLOR_BG: Record<AdversaryColor, string> = {
   Red:    'rgba(192,57,43,0.15)',
-  Blue:   'rgba(41,128,185,0.15)',
-  Cyan:   'rgba(0,180,216,0.12)',
+  Blue:   'rgba(40,120,214,0.15)',
+  Cyan:   'rgba(0,191,165,0.12)',
   Yellow: 'rgba(212,172,13,0.15)',
 };

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -6,7 +6,7 @@ import type {
 } from '../types/game';
 import { createDeck, drawCard, deckKey } from '../lib/deck';
 import { calcInitiative, sortActivations, numberActivations } from '../lib/initiative';
-import { CLASS_FILE, SPECIES_FILE } from '../lib/adversaries';
+import { CLASS_FILE, SPECIES_FILE, ADVERSARY_TYPES } from '../lib/adversaries';
 import { saveState, clearSavedState, isAutosaveEnabled } from '../lib/persistence';
 import type { SavedState } from '../lib/persistence';
 
@@ -27,6 +27,7 @@ const initialSetup: SetupState = {
   selectedTypeName: null,
   difficulty: 1,
   colorToggles: { Red: true, Blue: true, Cyan: true, Yellow: true },
+  selectedTypes: [],
 };
 
 const initialTurn: TurnState = {
@@ -94,7 +95,30 @@ export function toggleSetupColor(color: AdversaryColor): void {
   }));
 }
 
+// Toggle a type in the mission's "in play" list and focus it for stats preview.
+export function toggleSetupType(name: string): void {
+  gameStore.update(s => {
+    const types = s.setup.selectedTypes;
+    const next = types.includes(name) ? types.filter(n => n !== name) : [...types, name];
+    return { ...s, setup: { ...s.setup, selectedTypeName: name, selectedTypes: next } };
+  });
+}
+
 export function goToBattle(): void {
+  gameStore.update(s => ({ ...s, phase: 'battle' }));
+}
+
+// Batch-add all selected types with current difficulty then start battle.
+// All four colors are always included in the simplified setup flow.
+export async function startBattle(): Promise<void> {
+  const { setup } = get(gameStore);
+  // Reset turn state (keeps jsonCache for efficiency)
+  gameStore.update(s => ({ ...s, turn: { ...initialTurn } }));
+  const allColors: Record<AdversaryColor, boolean> = { Red: true, Blue: true, Cyan: true, Yellow: true };
+  for (const name of setup.selectedTypes) {
+    const type = ADVERSARY_TYPES.find(t => t.name === name);
+    if (type) await addAdversaryGroup(type, setup.difficulty, allColors);
+  }
   gameStore.update(s => ({ ...s, phase: 'battle' }));
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -104,10 +104,10 @@ html, body {
   text-decoration-color: rgba(212, 172, 13, 0.5);
 }
 .kw-die-cyan {
-  background: rgba(0, 180, 216, 0.12);
-  border: 1px solid rgba(0, 180, 216, 0.3);
+  background: rgba(0, 191, 165, 0.12);
+  border: 1px solid rgba(0, 191, 165, 0.3);
   color: var(--color-cyan);
-  text-decoration-color: rgba(0, 180, 216, 0.4);
+  text-decoration-color: rgba(0, 191, 165, 0.4);
 }
 
 /* Condition keyword badges inside effect/trigger text */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -11,8 +11,8 @@
 
   /* Unit colors */
   --color-red:      #c0392b;
-  --color-blue:     #2980b9;
-  --color-cyan:     #00b4d8;
+  --color-blue:     #2878d6;
+  --color-cyan:     #00bfa5;
   --color-yellow:   #d4ac0d;
   --color-positive: #3a7a4a;
 
@@ -49,8 +49,8 @@
 
   /* Per-color background tints */
   --color-red-bg:    rgba(192,57,43,0.15);
-  --color-blue-bg:   rgba(41,128,185,0.15);
-  --color-cyan-bg:   rgba(0,180,216,0.12);
+  --color-blue-bg:   rgba(40,120,214,0.15);
+  --color-cyan-bg:   rgba(0,191,165,0.12);
   --color-yellow-bg: rgba(212,172,13,0.15);
 
   /* Shadows */

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -86,6 +86,7 @@ export interface SetupState {
   selectedTypeName: string | null;
   difficulty: DifficultyLevel;
   colorToggles: Record<AdversaryColor, boolean>;
+  selectedTypes: string[]; // types toggled "in play" for the upcoming mission
 }
 
 // Runtime turn state


### PR DESCRIPTION
In basic turn tracker app we don't want to track individual units so far, which means we track "classes". And since the difficulty AFAIK sets difficulty type for all adversaries for a given mission - we can get away with just: a) difficulty switch b) per adversary type toggle