### PR TITLE
sort same initiative by card color order

### DIFF
--- a/src/lib/initiative.test.ts
+++ b/src/lib/initiative.test.ts
@@ -22,11 +22,33 @@ function makeEntry(unit: AdversaryUnit, initiative: number): ActivationEntry {
   return {
     unit,
     speciesCard: { Name: 'S', Cost: 0, Actions: [] },
-    classCard:   { Name: 'C', Cost: 0, Actions: [] },
+    classCard:   { Color: unit.color, Name: 'C', Cost: 0, Actions: [] },
     initiative,
     activationOrder: 0,
     speciesCardIndex: 0,
     classCardIndex: 0,
+    classCardOrderIndex: 0,
+    drawGroupOrder: 0,
+  };
+}
+
+function makeEntryWithMeta(
+  unit: AdversaryUnit,
+  initiative: number,
+  classCost: number,
+  classCardOrderIndex: number,
+  drawGroupOrder: number
+): ActivationEntry {
+  return {
+    unit,
+    speciesCard: { Name: 'S', Cost: 0, Actions: [] },
+    classCard:   { Color: unit.color, Name: 'C', Cost: classCost, Actions: [] },
+    initiative,
+    activationOrder: 0,
+    speciesCardIndex: 0,
+    classCardIndex: 0,
+    classCardOrderIndex,
+    drawGroupOrder,
   };
 }
 
@@ -64,15 +86,86 @@ describe('sortActivations', () => {
     const sorted = sortActivations(entries);
     expect(sorted.map(e => e.initiative)).toEqual([2, 5, 8]);
   });
-  it('tie-breaks by COLOR_ORDER: Red < Blue < Cyan < Yellow', () => {
+  it('tie-breaks same-cost entries by class card JSON order', () => {
     const entries = [
-      makeEntry(makeUnit('Yellow'), 3),
-      makeEntry(makeUnit('Red'),    3),
-      makeEntry(makeUnit('Cyan'),   3),
-      makeEntry(makeUnit('Blue'),   3),
+      makeEntryWithMeta(makeUnit('Yellow'), 3, 3, 1, 0),
+      makeEntryWithMeta(makeUnit('Red'),    3, 3, 3, 0),
+      makeEntryWithMeta(makeUnit('Cyan'),   3, 3, 0, 0),
+      makeEntryWithMeta(makeUnit('Blue'),   3, 3, 2, 0),
     ];
     const sorted = sortActivations(entries);
-    expect(sorted.map(e => e.unit.color)).toEqual(['Red', 'Blue', 'Cyan', 'Yellow']);
+    expect(sorted.map(e => e.unit.color)).toEqual(['Cyan', 'Yellow', 'Blue', 'Red']);
+  });
+  it('keeps initiative as the primary sort before class card order', () => {
+    const entries = [
+      makeEntryWithMeta(makeUnit('Yellow'), 4, 3, 0, 0),
+      makeEntryWithMeta(makeUnit('Red'),    2, 1, 3, 0),
+      makeEntryWithMeta(makeUnit('Cyan'),   3, 2, 1, 0),
+      makeEntryWithMeta(makeUnit('Blue'),   1, 0, 2, 0),
+    ];
+    const sorted = sortActivations(entries);
+    expect(sorted.map(e => e.initiative)).toEqual([1, 2, 3, 4]);
+  });
+  it('keeps cross-group equal initiatives in draw group order', () => {
+    const entries = [
+      makeEntryWithMeta(makeUnit('Yellow'), 3, 3, 1, 1),
+      makeEntryWithMeta(makeUnit('Red'),    3, 3, 2, 0),
+      makeEntryWithMeta(makeUnit('Cyan'),   3, 3, 0, 1),
+      makeEntryWithMeta(makeUnit('Blue'),   3, 3, 3, 0),
+    ];
+    const sorted = sortActivations(entries);
+    expect(sorted.map(e => `${e.drawGroupOrder}:${e.unit.color}`)).toEqual([
+      '0:Red',
+      '0:Blue',
+      '1:Cyan',
+      '1:Yellow',
+    ]);
+  });
+  it('keeps different adversary types grouped while preserving per-type card order', () => {
+    const typeAEntries = [
+      makeEntryWithMeta(
+        { ...makeUnit('Yellow'), adversaryName: 'TypeA', id: 'TypeA:Yellow' },
+        4,
+        4,
+        1,
+        0
+      ),
+      makeEntryWithMeta(
+        { ...makeUnit('Cyan'), adversaryName: 'TypeA', id: 'TypeA:Cyan' },
+        4,
+        4,
+        0,
+        0
+      ),
+    ];
+    const typeBEntries = [
+      makeEntryWithMeta(
+        { ...makeUnit('Red'), adversaryName: 'TypeB', id: 'TypeB:Red' },
+        4,
+        4,
+        1,
+        1
+      ),
+      makeEntryWithMeta(
+        { ...makeUnit('Blue'), adversaryName: 'TypeB', id: 'TypeB:Blue' },
+        4,
+        4,
+        0,
+        1
+      ),
+    ];
+    const sorted = sortActivations([
+      typeBEntries[0],
+      typeAEntries[0],
+      typeBEntries[1],
+      typeAEntries[1],
+    ]);
+    expect(sorted.map(e => `${e.unit.adversaryName}:${e.unit.color}`)).toEqual([
+      'TypeA:Cyan',
+      'TypeA:Yellow',
+      'TypeB:Blue',
+      'TypeB:Red',
+    ]);
   });
 });
 

--- a/src/lib/initiative.ts
+++ b/src/lib/initiative.ts
@@ -1,6 +1,4 @@
-import type { AdversaryColor, AdversaryUnit, ActivationEntry, SpeciesCard, ColorCard } from '../types/game';
-
-const COLOR_ORDER: AdversaryColor[] = ['Red', 'Blue', 'Cyan', 'Yellow'];
+import type { AdversaryUnit, ActivationEntry, SpeciesCard, ColorCard } from '../types/game';
 
 export function calcInitiative(
   unit: AdversaryUnit,
@@ -14,7 +12,14 @@ export function calcInitiative(
 export function sortActivations(entries: ActivationEntry[]): ActivationEntry[] {
   return [...entries].sort((a, b) => {
     if (a.initiative !== b.initiative) return a.initiative - b.initiative;
-    return COLOR_ORDER.indexOf(a.unit.color) - COLOR_ORDER.indexOf(b.unit.color);
+    if (a.drawGroupOrder !== b.drawGroupOrder) return a.drawGroupOrder - b.drawGroupOrder;
+    if (
+      a.classCardIndex === b.classCardIndex &&
+      a.classCard.Cost === b.classCard.Cost
+    ) {
+      return a.classCardOrderIndex - b.classCardOrderIndex;
+    }
+    return 0;
   });
 }
 

--- a/src/stores/gameStore.test.ts
+++ b/src/stores/gameStore.test.ts
@@ -40,6 +40,8 @@ function makeEntry(unit: AdversaryUnit, order: number): ActivationEntry {
     activationOrder: order,
     speciesCardIndex: 0,
     classCardIndex: 0,
+    classCardOrderIndex: 0,
+    drawGroupOrder: 0,
   };
 }
 

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -212,6 +212,13 @@ export function drawTurn(): void {
     const livingUnits = turn.units.filter(u => u.alive);
     if (livingUnits.length === 0) return s;
 
+    const groupOrderByName = new Map<string, number>();
+    for (const unit of turn.units) {
+      if (!groupOrderByName.has(unit.adversaryName)) {
+        groupOrderByName.set(unit.adversaryName, groupOrderByName.size);
+      }
+    }
+
     const groups = new Map<string, AdversaryUnit[]>();
     for (const unit of livingUnits) {
       const key = deckKey(unit.species, unit.className);
@@ -233,13 +240,17 @@ export function drawTurn(): void {
       const classEntry  = classJson[classIndex];
 
       for (const unit of units) {
-        const classCard  = classEntry.find(c => c.Color === unit.color) ?? classEntry[0];
+        const classCardOrderIndex = classEntry.findIndex(c => c.Color === unit.color);
+        const classCard  = classCardOrderIndex >= 0 ? classEntry[classCardOrderIndex] : classEntry[0];
         const initiative = calcInitiative(unit, speciesCard, classEntry);
+        const drawGroupOrder = groupOrderByName.get(unit.adversaryName) ?? Number.MAX_SAFE_INTEGER;
         entries.push({
           unit, speciesCard, classCard, initiative,
           activationOrder: 0,
           speciesCardIndex: speciesIndex,
           classCardIndex:   classIndex,
+          classCardOrderIndex: classCardOrderIndex >= 0 ? classCardOrderIndex : 0,
+          drawGroupOrder,
         });
       }
     }

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -76,6 +76,8 @@ export interface ActivationEntry {
   activationOrder: number;    // 1-based after sorting
   speciesCardIndex: number;   // drawn index for art URL
   classCardIndex: number;     // drawn index for art URL
+  classCardOrderIndex: number; // color order on the drawn class card JSON entry
+  drawGroupOrder: number;      // stable adversary-group order used for cross-type initiative ties
 }
 
 // App-level phase drives screen routing


### PR DESCRIPTION
Preserve 'color' order actions of adversary (when initiative has ties)
Keeps different adversary types grouped when have initiative ties

Addresses https://github.com/sigman78/phantom-companion/issues/12